### PR TITLE
Backend enhanced event emitter usage

### DIFF
--- a/backend/modules/experiment.py
+++ b/backend/modules/experiment.py
@@ -230,6 +230,7 @@ class Experiment:
             f"{repr(participant)} joined Experiment. "
             f"Participants connected to experiment: {list(self._participants.values())}"
         )
+        participant.add_listener("disconnected", self.remove_participant)
 
     def remove_participant(self, participant: _participant.Participant):
         """Remove an participant from this experiment.
@@ -345,6 +346,7 @@ class Experiment:
         self._logger.debug(
             f"Experimenters connected to experiment: {self._experimenters}"
         )
+        experimenter.add_listener("disconnected", self.remove_experimenter)
 
     def remove_experimenter(self, experimenter: _experimenter.Experimenter):
         """Remove an experimenter from this experiment.

--- a/backend/modules/experimenter.py
+++ b/backend/modules/experimenter.py
@@ -107,13 +107,6 @@ class Experimenter(User):
             New state of the connection this Experimenter has with the client.
         """
         self._logger.debug(f"Handle state change. State: {state}")
-        if state in [ConnectionState.CLOSED, ConnectionState.FAILED]:
-            if self._experiment is not None:
-                self._logger.debug("Removing self from Experiment")
-                self._experiment.remove_experimenter(self)
-            self._logger.debug("Removing self from Hub")
-            self._hub.remove_experimenter(self)
-
         if state is ConnectionState.CONNECTED:
             self._logger.info(f"Experimenter connected. {str(self)}")
             await self._subscribe_to_participants_streams()

--- a/backend/modules/participant.py
+++ b/backend/modules/participant.py
@@ -150,11 +150,6 @@ class Participant(User):
             New state of the connection this Participant has with the client.
         """
         self._logger.debug(f"Handle state change. State: {state}")
-        if state in [ConnectionState.CLOSED, ConnectionState.FAILED]:
-            self._logger.debug("Removing self from experiment")
-            self._experiment.remove_participant(self)
-            return
-
         if state is ConnectionState.CONNECTED:
             self._logger.info(f"Participant connected. {self}")
             tasks = []


### PR DESCRIPTION
# Changes

-   Users no longer remove themselves from the Hub / an Experiment. Instead, the "disconnected" event is used to remove a user.
    -   When a user is added (e.g. to an Experiment), the experiment adds a event listener for the "disconnected" event. This should make the code a bit cleaner and more robust.
-   data module & session manager now use events instead of on_update function
    -   Removed custom init functions from data classes
    -   Added factory functions for SessionData and ParticipantData
    -   SessionData now also uses \_BaseDataClass, removed now redundant functionality
