### PR TITLE
Backend multiprocessing support

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -25,6 +25,8 @@ The backend can be configured using the `backend/config.json`.
 -   `log_file` - null | str : If given, the logger will write the log into the file instead of the console
 -   `log_dependencies` - str : Logging level for project 3rd party dependencies (see [requirements.txt](./requirements.txt)). Must be one of: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`. Default: `WARNING`. Using `INFO` or `DEBUG` may lead to a strong increase in output.
 -   `ping_subprocesses` - float : If greater than 0, all subprocesses will be pinged in an interval defined by the value of `ping_subprocesses` (in seconds). Used for debugging, default should be `0.0`.
+-   `experimenter_multiprocessing` - bool : If true, experimenter connections will be executed on independent processes
+-   `participant_multiprocessing` - bool : If true, participant connections will be executed on independent processes
 
 ### Logging overview
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -24,6 +24,7 @@ The backend can be configured using the `backend/config.json`.
 -   `log` - str : Logging level for Hub. Must be one of: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`. Default: `INFO`
 -   `log_file` - null | str : If given, the logger will write the log into the file instead of the console
 -   `log_dependencies` - str : Logging level for project 3rd party dependencies (see [requirements.txt](./requirements.txt)). Must be one of: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`. Default: `WARNING`. Using `INFO` or `DEBUG` may lead to a strong increase in output.
+-   `ping_subprocesses` - float : If greater than 0, all subprocesses will be pinged in an interval defined by the value of `ping_subprocesses` (in seconds). Used for debugging, default should be `0.0`.
 
 ### Logging overview
 

--- a/backend/config.json
+++ b/backend/config.json
@@ -7,5 +7,6 @@
 	"log_dependencies": "WARNING",
 	"https": false,
 	"ssl_cert": "./certificate/cert.crt",
-	"ssl_key": "./certificate/key.key"
+	"ssl_key": "./certificate/key.key",
+	"ping_subprocesses": 0.0
 }

--- a/backend/config.json
+++ b/backend/config.json
@@ -8,5 +8,7 @@
 	"https": false,
 	"ssl_cert": "./certificate/cert.crt",
 	"ssl_key": "./certificate/key.key",
-	"ping_subprocesses": 0.0
+	"ping_subprocesses": 0.0,
+	"experimenter_multiprocessing": false,
+	"participant_multiprocessing": true
 }

--- a/backend/modules/config.py
+++ b/backend/modules/config.py
@@ -43,6 +43,7 @@ class Config:
             "https": bool,
             "log": str,
             "log_dependencies": str,
+            "ping_subprocesses": float,
         }
         for key in data_types:
             if key not in config:
@@ -72,6 +73,7 @@ class Config:
         self.https = config["https"]
         self.log = config["log"]
         self.log_dependencies = config["log_dependencies"]
+        self.ping_subprocesses = config["ping_subprocesses"]
 
         # Parse log_file
         self.log_file = config.get("log_file")
@@ -97,19 +99,14 @@ class Config:
                 raise FileNotFoundError(f"Did not find ssl_key file: {self.ssl_key}")
 
     def __str__(self) -> str:
-        """Get string representation of parameters in this Config.
-
-        Format: "host: <host>, port: <port>, environment: <environment>."
-        """
+        """Get string representation of parameters in this Config."""
         return (
-            f"host: {self.host}, port: {self.port}, environment: {self.environment}, "
-            f"ssl_cert: {self.ssl_cert}, ssl_key: {self.ssl_key}, log={self.log}, log_"
-            f"dependencies={self.log_dependencies}, log_file={self.log_file}."
+            f"host={self.host}, port={self.port}, environment={self.environment}, "
+            f"https={self.https}, ssl_cert={self.ssl_cert}, ssl_key={self.ssl_key}, "
+            f"log={self.log}, log_dependencies={self.log_dependencies}, log_file="
+            f"{self.log_file}, ping_subprocesses={self.ping_subprocesses}."
         )
 
     def __repr__(self) -> str:
-        """Get representation of this Config obj.
-
-        Format: "Config(host: <host>, port: <port>, environment: <environment>.)"
-        """
+        """Get representation of this Config obj."""
         return f"Config({str(self)})"

--- a/backend/modules/config.py
+++ b/backend/modules/config.py
@@ -22,6 +22,10 @@ class Config:
     log_file: str | None
     log_dependencies: Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]
 
+    ping_subprocesses: float
+    experimenter_multiprocessing: bool
+    participant_multiprocessing: bool
+
     def __init__(self):
         """Load config from `backend/config.json`.
 
@@ -44,6 +48,8 @@ class Config:
             "log": str,
             "log_dependencies": str,
             "ping_subprocesses": float,
+            "experimenter_multiprocessing": bool,
+            "participant_multiprocessing": bool,
         }
         for key in data_types:
             if key not in config:
@@ -74,6 +80,8 @@ class Config:
         self.log = config["log"]
         self.log_dependencies = config["log_dependencies"]
         self.ping_subprocesses = config["ping_subprocesses"]
+        self.experimenter_multiprocessing = config["experimenter_multiprocessing"]
+        self.participant_multiprocessing = config["participant_multiprocessing"]
 
         # Parse log_file
         self.log_file = config.get("log_file")
@@ -104,7 +112,9 @@ class Config:
             f"host={self.host}, port={self.port}, environment={self.environment}, "
             f"https={self.https}, ssl_cert={self.ssl_cert}, ssl_key={self.ssl_key}, "
             f"log={self.log}, log_dependencies={self.log_dependencies}, log_file="
-            f"{self.log_file}, ping_subprocesses={self.ping_subprocesses}."
+            f"{self.log_file}, ping_subprocesses={self.ping_subprocesses},"
+            f"experimenter_multiprocessing={self.experimenter_multiprocessing}, "
+            f"participant_multiprocessing={self.participant_multiprocessing}."
         )
 
     def __repr__(self) -> str:

--- a/backend/modules/connection.py
+++ b/backend/modules/connection.py
@@ -186,8 +186,8 @@ class Connection(ConnectionInterface):
         subconnection_id = generate_unique_id(list(self._sub_connections.keys()))
         sc = SubConnection(
             subconnection_id,
-            self._incoming_video,
-            self._incoming_audio,
+            self._incoming_video.subscribe(),
+            self._incoming_audio.subscribe(),
             participant_summary,
             self._log_name_suffix,
         )

--- a/backend/modules/connection.py
+++ b/backend/modules/connection.py
@@ -37,9 +37,6 @@ class Connection(ConnectionInterface):
     Extends AsyncIOEventEmitter, providing the following events:
     - `state_change` : modules.connection_state.ConnectionState
         Emitted when the state of this connection changes.
-    - `tracks_complete` : tuple of modules.track.VideoTrackHandler and modules.track.AudioTrackHandler
-        Emitted when both tracks are received from the client and ready to be
-        distributed / subscribed to.
 
     Notes
     -----
@@ -338,9 +335,6 @@ class Connection(ConnectionInterface):
         else:
             self._logger.error(f"Unknown track kind {track.kind}. Ignoring track")
             return
-
-        if self._incoming_audio is not None and self._incoming_video is not None:
-            self.emit("tracks_complete", (self._incoming_video, self._incoming_audio))
 
         @track.on("ended")
         def _on_ended():

--- a/backend/modules/connection.py
+++ b/backend/modules/connection.py
@@ -14,6 +14,7 @@ import asyncio
 import logging
 import json
 
+from modules.connection_interface import ConnectionInterface
 from modules.tracks import AudioTrackHandler, VideoTrackHandler
 from modules.util import generate_unique_id
 from modules.connection_state import ConnectionState, parse_connection_state
@@ -28,11 +29,11 @@ from custom_types.connection import (
 )
 
 
-class Connection(AsyncIOEventEmitter):
-    """Connection with a single client.
+class Connection(ConnectionInterface):
+    """Connection with a single client using multiple sub-connections.
 
-    Manages one or multiple WebRTC connections with the same client.  Provides interface
-    unaffected by the number of actual connections.
+    Manages one or multiple WebRTC connections with the same client.  Implements
+    ConnectionInterface.
 
     Extends AsyncIOEventEmitter, providing the following events:
     - `state_change` : modules.connection_state.ConnectionState
@@ -459,6 +460,9 @@ class Connection(AsyncIOEventEmitter):
                     await transceiver.stop()
                     break
             await self._check_if_closed()
+
+
+ConnectionInterface.register(Connection)
 
 
 class SubConnection(AsyncIOEventEmitter):

--- a/backend/modules/connection.py
+++ b/backend/modules/connection.py
@@ -235,7 +235,7 @@ class Connection(ConnectionInterface):
         await sub_connection.stop()
         return True
 
-    def set_muted(self, video: bool, audio: bool) -> None:
+    async def set_muted(self, video: bool, audio: bool) -> None:
         """Set the muted state for this connection.
 
         Parameters

--- a/backend/modules/connection.py
+++ b/backend/modules/connection.py
@@ -10,13 +10,13 @@ from aiortc import (
     RTCRtpSender,
 )
 from pyee.asyncio import AsyncIOEventEmitter
+import shortuuid
 import asyncio
 import logging
 import json
 
 from modules.connection_interface import ConnectionInterface
 from modules.tracks import AudioTrackHandler, VideoTrackHandler
-from modules.util import generate_unique_id
 from modules.connection_state import ConnectionState, parse_connection_state
 
 from custom_types.error import ErrorDict
@@ -166,7 +166,7 @@ class Connection(ConnectionInterface):
     ) -> ConnectionOfferDict:
         # For docstring see ConnectionInterface or hover over function declaration
 
-        subconnection_id = generate_unique_id(list(self._sub_connections.keys()))
+        subconnection_id = shortuuid.uuid()
         sc = SubConnection(
             subconnection_id,
             self._incoming_video.subscribe(),

--- a/backend/modules/connection.py
+++ b/backend/modules/connection.py
@@ -23,7 +23,6 @@ from custom_types.error import ErrorDict
 from custom_types.message import MessageDict, is_valid_messagedict
 from custom_types.participant_summary import ParticipantSummaryDict
 from custom_types.connection import (
-    is_valid_connection_answer_dict,
     RTCSessionDescriptionDict,
     ConnectionOfferDict,
     ConnectionAnswerDict,
@@ -33,8 +32,7 @@ from custom_types.connection import (
 class Connection(ConnectionInterface):
     """Connection with a single client using multiple sub-connections.
 
-    Manages one or multiple WebRTC connections with the same client.  Implements
-    ConnectionInterface.
+    Implements modules.connection_interface.ConnectionInterface.
 
     Extends AsyncIOEventEmitter, providing the following events:
     - `state_change` : modules.connection_state.ConnectionState
@@ -123,12 +121,7 @@ class Connection(ConnectionInterface):
         )
 
     async def stop(self) -> None:
-        """Stop this connection.
-
-        Stopps all incoming and outgoing streams and emits the `state_change` event.
-        When finished, it removes all event listeners from this Connection, as no more
-        events will be emitted.
-        """
+        # For docstring see ConnectionInterface or hover over function declaration
         if self._stopped:
             return
         self._stopped = True
@@ -154,13 +147,7 @@ class Connection(ConnectionInterface):
         self.remove_all_listeners()
 
     async def send(self, data: MessageDict | dict) -> None:
-        """Send `data` to peer over the datachannel.
-
-        Parameters
-        ----------
-        data : MessageDict or dict
-            Data that will be stringified and send to the peer.
-        """
+        # For docstring see ConnectionInterface or hover over function declaration
         if self._dc is None or self._dc.readyState != "open":
             self._logger.warning("Can not send data because datachannel is not open")
             await self._set_failed_state_and_close()
@@ -171,13 +158,13 @@ class Connection(ConnectionInterface):
 
     @property
     def state(self) -> ConnectionState:
-        """Get the modules.connection_state.ConnectionState the Connection is in."""
+        # For docstring see ConnectionInterface or hover over function declaration
         return self._state
 
     async def create_subscriber_offer(
         self, participant_summary: ParticipantSummaryDict | None
     ) -> ConnectionOfferDict:
-        """TODO document"""
+        # For docstring see ConnectionInterface or hover over function declaration
 
         # TODO
         assert self._incoming_video is not None
@@ -197,7 +184,7 @@ class Connection(ConnectionInterface):
         return offer
 
     async def handle_subscriber_answer(self, answer: ConnectionAnswerDict) -> None:
-        """TODO document"""
+        # For docstring see ConnectionInterface or hover over function declaration
         subconnection_id = answer["id"]
         sc = self._sub_connections.get(subconnection_id)
         if sc is None:
@@ -211,23 +198,7 @@ class Connection(ConnectionInterface):
         await sc.handle_answer(answer_description)
 
     async def stop_subconnection(self, subconnection_id: str) -> bool:
-        """Stop the subconnection with `stream_id`.
-
-        Parameters
-        ----------
-        subconnection_id : str
-            ID of the outgoing SubConnection that will be stopped.
-
-        Returns
-        -------
-        bool
-            True if a outgoing stream with `subconnection_id` was found and closed.
-            Otherwise False.
-
-        See Also
-        --------
-        add_outgoing_stream : add a new outgoing SubConnection.
-        """
+        # For docstring see ConnectionInterface or hover over function declaration
         if subconnection_id not in self._sub_connections:
             return False
 
@@ -236,15 +207,7 @@ class Connection(ConnectionInterface):
         return True
 
     async def set_muted(self, video: bool, audio: bool) -> None:
-        """Set the muted state for this connection.
-
-        Parameters
-        ----------
-        video : bool
-            Whether the connection video should be muted.
-        audio : bool
-            Whether the connection audio should be muted.
-        """
+        # For docstring see ConnectionInterface or hover over function declaration
         if self._incoming_video is not None:
             self._incoming_video.muted = video
         if self._incoming_audio is not None:

--- a/backend/modules/connection.py
+++ b/backend/modules/connection.py
@@ -434,7 +434,10 @@ class SubConnection(AsyncIOEventEmitter):
         # video_track.on("ended", self.stop)
 
     async def generate_offer(self) -> ConnectionOfferDict:
-        """TODO document
+        """Generate offer for this subconnection.
+
+        This offer can then be send to a client, which should respond with an answer.
+        The answer should be passed to `handle_answer`.
 
         See Also
         --------

--- a/backend/modules/connection_interface.py
+++ b/backend/modules/connection_interface.py
@@ -81,6 +81,6 @@ class ConnectionInterface(AsyncIOEventEmitter, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def set_muted(self, video: bool, audio: bool) -> None:
+    async def set_muted(self, video: bool, audio: bool) -> None:
         """TODO document"""
         pass

--- a/backend/modules/connection_interface.py
+++ b/backend/modules/connection_interface.py
@@ -1,14 +1,14 @@
 """Provide the abstract `ConnectionInterface`."""
 
-from aiortc import MediaStreamTrack
+from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 from pyee.asyncio import AsyncIOEventEmitter
 
 from modules.connection_state import ConnectionState
-from modules.tracks import AudioTrackHandler, VideoTrackHandler
 
 from custom_types.message import MessageDict
 from custom_types.participant_summary import ParticipantSummaryDict
+from custom_types.connection import ConnectionOfferDict, ConnectionAnswerDict
 
 
 class ConnectionInterface(AsyncIOEventEmitter, metaclass=ABCMeta):
@@ -47,76 +47,40 @@ class ConnectionInterface(AsyncIOEventEmitter, metaclass=ABCMeta):
         """Get the modules.connection_state.ConnectionState the Connection is in."""
         pass
 
-    @property
     @abstractmethod
-    def incoming_audio(self) -> AudioTrackHandler | None:
-        """Get incoming audio track.
-
-        Returns
-        -------
-        modules.track.AudioTrackHandler or None
-            None if no audio was received by client (yet), otherwise AudioTrackHandler.
-        """
-        pass
-
-    @property
-    @abstractmethod
-    def incoming_video(self) -> VideoTrackHandler | None:
-        """Get incoming video track.
-
-        Returns
-        -------
-        modules.track.VideoTrackHandler or None
-            None if no video was received by client (yet), otherwise VideoTrackHandler.
-        """
+    async def create_subscriber_offer(
+        self, participant_summary: ParticipantSummaryDict | None
+    ) -> ConnectionOfferDict:
+        """TODO document"""
         pass
 
     @abstractmethod
-    async def add_outgoing_stream(
-        self,
-        video_track: MediaStreamTrack,
-        audio_track: MediaStreamTrack,
-        participant_summary: ParticipantSummaryDict | None,
-    ) -> str:
-        """Add an outgoing stream to Connection.
+    async def handle_subscriber_answer(self, answer: ConnectionAnswerDict) -> None:
+        """TODO document"""
+        pass
 
-        See implementation for details.
+    @abstractmethod
+    async def stop_subconnection(self, subconnection_id: str) -> bool:
+        """Stop the subconnection with `stream_id`.
 
         Parameters
         ----------
-        video_track : MediaStreamTrack
-            Video that will be used in the new SubConnection.
-        audio_track : MediaStreamTrack
-            Audio that will be used in the new SubConnection.
-        participant_summary : ParticipantSummaryDict or None
-            Optional participant summary that will be send to the client, informing it
-            about the details of the new stream.
-
-        Returns
-        -------
-        str
-            A new ID that identifies the new outgoing stream. It can be used to close
-            the stream again using `stop_outgoing_stream()`.
-        """
-        pass
-
-    @abstractmethod
-    async def stop_outgoing_stream(self, stream_id: str) -> bool:
-        """Stop the outgoing stream with `stream_id`.
-
-        Parameters
-        ----------
-        stream_id : str
-            ID of the outgoing stream that will be stopped.
+        subconnection_id : str
+            ID of the outgoing SubConnection that will be stopped.
 
         Returns
         -------
         bool
-            True if a outgoing stream with `stream_id` was found and closed. Otherwise
-            False.
+            True if a outgoing stream with `subconnection_id` was found and closed.
+            Otherwise False.
 
         See Also
         --------
-        add_outgoing_stream : add a new outgoing stream.
+        add_outgoing_stream : add a new outgoing SubConnection.
         """
+        pass
+
+    @abstractmethod
+    def set_muted(self, video: bool, audio: bool) -> None:
+        """TODO document"""
         pass

--- a/backend/modules/connection_interface.py
+++ b/backend/modules/connection_interface.py
@@ -18,6 +18,12 @@ class ConnectionInterface(AsyncIOEventEmitter, metaclass=ABCMeta):
     -----
     Do not instantiate directly, use subclasses / implementations of
     `ConnectionInterface` instead.
+
+    See Also
+    --------
+    modules.connection.Connection : Implementation for ConnectionInterface.
+    modules.connection_subprocess.ConnectionSubprocess :
+        Implementation for ConnectionInterface.
     """
 
     @abstractmethod
@@ -36,7 +42,7 @@ class ConnectionInterface(AsyncIOEventEmitter, metaclass=ABCMeta):
 
         Parameters
         ----------
-        data : MessageDict or dict
+        data : custom_types.message.MessageDict or dict
             Data that will be stringified and send to the connected client.
         """
         pass
@@ -51,17 +57,35 @@ class ConnectionInterface(AsyncIOEventEmitter, metaclass=ABCMeta):
     async def create_subscriber_offer(
         self, participant_summary: ParticipantSummaryDict | None
     ) -> ConnectionOfferDict:
-        """TODO document"""
+        """Create a subconnection offer.
+
+        Parameters
+        ----------
+        participant_summary : custom_types.participant_summary.ParticipantSummaryDict or None
+            Participant summary that will be included in the resulting offer.
+
+        Returns
+        -------
+        custom_types.connection.ConnectionOfferDict
+            Connection offer including the `participant_summary`.
+        """
         pass
 
     @abstractmethod
     async def handle_subscriber_answer(self, answer: ConnectionAnswerDict) -> None:
-        """TODO document"""
+        """Handle answer to a connection offer.
+
+        Parameters
+        ----------
+        answer : custom_types.connection.ConnectionAnswerDict
+            Answer to a custom_types.connection.ConnectionOfferDict created by this
+            connection.  The answer ID must match a offer ID send by this connection.
+        """
         pass
 
     @abstractmethod
     async def stop_subconnection(self, subconnection_id: str) -> bool:
-        """Stop the subconnection with `stream_id`.
+        """Stop the subconnection with `subconnection_id`.
 
         Parameters
         ----------
@@ -82,5 +106,13 @@ class ConnectionInterface(AsyncIOEventEmitter, metaclass=ABCMeta):
 
     @abstractmethod
     async def set_muted(self, video: bool, audio: bool) -> None:
-        """TODO document"""
+        """Set the muted state for this connection.
+
+        Parameters
+        ----------
+        video : bool
+            Whether the video track should be muted.
+        audio : bool
+            Whether the audio track should be muted.
+        """
         pass

--- a/backend/modules/connection_interface.py
+++ b/backend/modules/connection_interface.py
@@ -1,0 +1,122 @@
+"""Provide the abstract `ConnectionInterface`."""
+
+from aiortc import MediaStreamTrack
+from abc import ABCMeta, abstractmethod
+from pyee.asyncio import AsyncIOEventEmitter
+
+from modules.connection_state import ConnectionState
+from modules.tracks import AudioTrackHandler, VideoTrackHandler
+
+from custom_types.message import MessageDict
+from custom_types.participant_summary import ParticipantSummaryDict
+
+
+class ConnectionInterface(AsyncIOEventEmitter, metaclass=ABCMeta):
+    """Abstract interface for connections with clients.
+
+    Notes
+    -----
+    Do not instantiate directly, use subclasses / implementations of
+    `ConnectionInterface` instead.
+    """
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Stop this connection.
+
+        Stopps all incoming and outgoing streams and emits the `state_change` event.
+        When finished, it removes all event listeners from this Connection, as no more
+        events will be emitted.
+        """
+        pass
+
+    @abstractmethod
+    async def send(self, data: MessageDict | dict) -> None:
+        """Send `data` to connected client over the datachannel.
+
+        Parameters
+        ----------
+        data : MessageDict or dict
+            Data that will be stringified and send to the connected client.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def state(self) -> ConnectionState:
+        """Get the modules.connection_state.ConnectionState the Connection is in."""
+        pass
+
+    @property
+    @abstractmethod
+    def incoming_audio(self) -> AudioTrackHandler | None:
+        """Get incoming audio track.
+
+        Returns
+        -------
+        modules.track.AudioTrackHandler or None
+            None if no audio was received by client (yet), otherwise AudioTrackHandler.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def incoming_video(self) -> VideoTrackHandler | None:
+        """Get incoming video track.
+
+        Returns
+        -------
+        modules.track.VideoTrackHandler or None
+            None if no video was received by client (yet), otherwise VideoTrackHandler.
+        """
+        pass
+
+    @abstractmethod
+    async def add_outgoing_stream(
+        self,
+        video_track: MediaStreamTrack,
+        audio_track: MediaStreamTrack,
+        participant_summary: ParticipantSummaryDict | None,
+    ) -> str:
+        """Add an outgoing stream to Connection.
+
+        See implementation for details.
+
+        Parameters
+        ----------
+        video_track : MediaStreamTrack
+            Video that will be used in the new SubConnection.
+        audio_track : MediaStreamTrack
+            Audio that will be used in the new SubConnection.
+        participant_summary : ParticipantSummaryDict or None
+            Optional participant summary that will be send to the client, informing it
+            about the details of the new stream.
+
+        Returns
+        -------
+        str
+            A new ID that identifies the new outgoing stream. It can be used to close
+            the stream again using `stop_outgoing_stream()`.
+        """
+        pass
+
+    @abstractmethod
+    async def stop_outgoing_stream(self, stream_id: str) -> bool:
+        """Stop the outgoing stream with `stream_id`.
+
+        Parameters
+        ----------
+        stream_id : str
+            ID of the outgoing stream that will be stopped.
+
+        Returns
+        -------
+        bool
+            True if a outgoing stream with `stream_id` was found and closed. Otherwise
+            False.
+
+        See Also
+        --------
+        add_outgoing_stream : add a new outgoing stream.
+        """
+        pass

--- a/backend/modules/connection_runner.py
+++ b/backend/modules/connection_runner.py
@@ -9,6 +9,7 @@ from aiortc import RTCSessionDescription
 from custom_types.message import MessageDict
 from custom_types.connection import ConnectionOfferDict
 
+from modules.config import Config
 from modules.connection_state import ConnectionState
 from modules.connection import Connection, connection_factory
 from modules.subprocess_logging import SubprocessLoggingHandler
@@ -31,10 +32,14 @@ class ConnectionRunner:
         self._running = False
         self._tasks = []
         self._stopped_event = asyncio.Event()
+        config = Config()
 
-        log_handler = SubprocessLoggingHandler(self._send_command)
-        logging.basicConfig(level=logging.DEBUG, handlers=[log_handler])
-        dependencies_log_level = logging.INFO
+        # Setup logging for subprocess
+        handler = SubprocessLoggingHandler(self._send_command)
+        logging.basicConfig(level=logging.getLevelName(config.log), handlers=[handler])
+
+        # Set logging level for libraries
+        dependencies_log_level = logging.getLevelName(config.log_dependencies)
         logging.getLogger("aiohttp").setLevel(dependencies_log_level)
         logging.getLogger("aioice").setLevel(dependencies_log_level)
         logging.getLogger("aiortc").setLevel(dependencies_log_level)

--- a/backend/modules/connection_runner.py
+++ b/backend/modules/connection_runner.py
@@ -63,7 +63,7 @@ class ConnectionRunner:
         )
 
         await self._listen_for_messages()
-        self._logger.info("ConnectionRunner exiting")
+        self._logger.debug("ConnectionRunner exiting")
 
     async def stop(self) -> None:
         """TODO document"""
@@ -97,7 +97,7 @@ class ConnectionRunner:
         """TODO document"""
         data = msg["data"]
         command = msg["command"]
-        self._logger.debug(f"Received {command} command from main process")
+        # self._logger.debug(f"Received {command} command from main process")
 
         if self._connection is None:
             self._logger.warning(
@@ -120,6 +120,8 @@ class ConnectionRunner:
             case "SET_MUTED":
                 video, audio = data
                 await self._connection.set_muted(video, audio)
+            case _:
+                self._logger.error(f"Unrecognized command from main process: {command}")
 
     async def _read(self):
         """TODO document"""

--- a/backend/modules/connection_runner.py
+++ b/backend/modules/connection_runner.py
@@ -95,6 +95,7 @@ class ConnectionRunner:
 
     async def _handle_state_change(self, state: ConnectionState) -> None:
         """TODO document"""
+        self._send_command("STATE_CHANGE", state.value)
         if state in [ConnectionState.CLOSED, ConnectionState.FAILED]:
             logging.debug(f"Stopping, because state is {state}")
             await self.stop()

--- a/backend/modules/connection_runner.py
+++ b/backend/modules/connection_runner.py
@@ -1,8 +1,9 @@
+"""TODO document"""
 import asyncio
 import json
 import logging
 import sys
-from typing import Any, Callable, Coroutine
+from typing import Any
 from aiortc import RTCSessionDescription
 
 from custom_types.message import MessageDict
@@ -12,6 +13,8 @@ from modules.connection import Connection, connection_factory
 
 
 class ConnectionRunner:
+    """TODO document"""
+
     _connection: Connection | None
     _lock: asyncio.Lock
     _running: bool
@@ -19,6 +22,7 @@ class ConnectionRunner:
     _tasks: list[asyncio.Task]
 
     def __init__(self) -> None:
+        """TODO document"""
         self._connection = None
         self._lock = asyncio.Lock()
         self._running = False
@@ -30,16 +34,21 @@ class ConnectionRunner:
         offer: RTCSessionDescription,
         log_name_suffix: str,
     ) -> None:
+        """TODO document"""
         self._running = True
         answer, self._connection = await connection_factory(
             offer, self.handle_api_message, log_name_suffix
         )
         self._connection.add_listener("state_change", self._handle_state_change)
-        self.send("SET_LOCAL_DESCRIPTION", {"sdp": answer.sdp, "type": answer.type})
-        logging.info("Wait for _stopped_event")
+        self._send_command(
+            "SET_LOCAL_DESCRIPTION", {"sdp": answer.sdp, "type": answer.type}
+        )
+
         await self._listen_for_messages()
+        logging.info("ConnectionRunner finished")
 
     async def stop(self) -> None:
+        """TODO document"""
         logging.debug("Exiting")
         async with self._lock:
             self._running = False
@@ -48,11 +57,17 @@ class ConnectionRunner:
         self._stopped_event.set()
         logging.debug("Exit complete")
 
-    async def _listen_for_messages(self):
+    async def _listen_for_messages(self) -> None:
+        """TODO document"""
+        logging.debug("Listening for messages from main process")
         msg = ""
         while msg != "q":
             async with self._lock:
                 if not self._running:
+                    logging.debug(
+                        "Stop listening for messages from main process, running is "
+                        "False"
+                    )
                     return
             try:
                 msg = await asyncio.wait_for(self._read(), 5)
@@ -63,30 +78,32 @@ class ConnectionRunner:
             try:
                 parsed = json.loads(msg)
             except (json.JSONDecodeError, TypeError) as e:
-                logging.error(f"Failed to parse message from subprocess: {e}")
+                logging.error(f"Failed to parse message from main process: {e}")
                 continue
 
-            logging.info(f"_listen_for_messages Received {parsed}")
+            logging.info(f"Received command from main process: {parsed}")
             await self._handle_message(parsed)
 
-        logging.info("connection_subprocess finished")
-
     async def _handle_message(self, msg: dict):
+        """TODO document"""
         match msg["command"]:
             case "PING":
-                self.send("PONG", msg["data"])
+                self._send_command("PONG", msg["data"])
 
     async def _read(self):
+        """TODO document"""
         return await asyncio.get_event_loop().run_in_executor(None, sys.stdin.readline)
 
     async def _handle_state_change(self, state: ConnectionState) -> None:
+        """TODO document"""
         if state in [ConnectionState.CLOSED, ConnectionState.FAILED]:
             await self.stop()
 
     async def handle_api_message(self, message: MessageDict | Any) -> None:
+        """TODO document"""
         pass
 
-    def send(self, command, data):
+    def _send_command(self, command: str, data: str | int | float | dict) -> None:
         """Send to main process"""
         data = json.dumps({"command": command, "data": data})
         logging.info(f"Sending: {data}")

--- a/backend/modules/connection_runner.py
+++ b/backend/modules/connection_runner.py
@@ -116,6 +116,14 @@ class ConnectionRunner:
                     )
                     return
                 await self._connection.handle_subscriber_answer(data)
+            case "STOP_SUBCONNECTION":
+                if self._connection is None:
+                    logging.warning(
+                        "Failed to stop subconnection, connection not defined. Data: "
+                        f"{data}"
+                    )
+                    return
+                await self._connection.stop_subconnection(data)
 
     async def _read(self):
         """TODO document"""

--- a/backend/modules/connection_runner.py
+++ b/backend/modules/connection_runner.py
@@ -49,13 +49,12 @@ class ConnectionRunner:
 
     async def stop(self) -> None:
         """TODO document"""
-        logging.debug("Exiting")
+        logging.debug("Stopping")
         async with self._lock:
             self._running = False
         await asyncio.gather(*self._tasks)
-        logging.debug("Set _stopped_event")
         self._stopped_event.set()
-        logging.debug("Exit complete")
+        logging.debug("Stop complete")
 
     async def _listen_for_messages(self) -> None:
         """TODO document"""
@@ -97,6 +96,7 @@ class ConnectionRunner:
     async def _handle_state_change(self, state: ConnectionState) -> None:
         """TODO document"""
         if state in [ConnectionState.CLOSED, ConnectionState.FAILED]:
+            logging.debug(f"Stopping, because state is {state}")
             await self.stop()
 
     async def handle_api_message(self, message: MessageDict | Any) -> None:

--- a/backend/modules/connection_runner.py
+++ b/backend/modules/connection_runner.py
@@ -1,0 +1,80 @@
+import asyncio
+import json
+import logging
+from typing import Any, Callable, Coroutine
+from aiortc import RTCSessionDescription
+
+from custom_types.message import MessageDict
+
+from modules.connection_state import ConnectionState
+from modules.connection import Connection, connection_factory
+
+
+class ConnectionRunner:
+    _connection: Connection | None
+    _lock: asyncio.Lock
+    _running: bool
+    _stopped_event: asyncio.Event
+    _tasks: list[asyncio.Task]
+
+    def __init__(self) -> None:
+        self._connection = None
+        self._lock = asyncio.Lock()
+        self._running = False
+        self._tasks = []
+        self._stopped_event = asyncio.Event()
+
+    async def run(
+        self,
+        offer: RTCSessionDescription,
+        log_name_suffix: str,
+    ) -> None:
+        self._running = True
+        answer, self._connection = await connection_factory(
+            offer, self.handle_api_message, log_name_suffix
+        )
+        self._connection.add_listener("state_change", self._handle_state_change)
+        self.send("SET_LOCAL_DESCRIPTION", {"sdp": answer.sdp, "type": answer.type})
+
+        self._tasks.append(
+            asyncio.create_task(
+                self._listen_for_messages(),
+                name="ConnectionRunner._listen_for_messages",
+            )
+        )
+        logging.info("Wait for _stopped_event")
+        await self._stopped_event.wait()
+
+    async def stop(self) -> None:
+        logging.debug("Exiting")
+        async with self._lock:
+            self._running = False
+        await asyncio.gather(*self._tasks)
+        logging.debug("Set _stopped_event")
+        self._stopped_event.set()
+        logging.debug("Exit complete")
+
+    async def _listen_for_messages(self):
+        val = ""
+        while val != "q":
+            async with self._lock:
+                if not self._running:
+                    return
+            val = input()
+            logging.info(f"_listen_for_messages Received {val}")
+            self.send("ECHO", val)
+
+        logging.info("connection_subprocess finished")
+
+    async def _handle_state_change(self, state: ConnectionState) -> None:
+        if state in [ConnectionState.CLOSED, ConnectionState.FAILED]:
+            await self.stop()
+
+    async def handle_api_message(self, message: MessageDict | Any) -> None:
+        pass
+
+    def send(self, command, data):
+        """Send to main process"""
+        data = json.dumps({"command": command, "data": data})
+        logging.info(f"Sending: {data}")
+        print(data)

--- a/backend/modules/connection_runner.py
+++ b/backend/modules/connection_runner.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 import sys
-import time
 from typing import Any, Callable, Coroutine
 from aiortc import RTCSessionDescription
 
@@ -68,13 +67,14 @@ class ConnectionRunner:
                 continue
 
             logging.info(f"_listen_for_messages Received {parsed}")
-            if parsed["command"] == "PING":
-                t = round(time.time() * 1000)
-                self.send("ECHO", {"time": t, "diff": t - parsed["time"]})
-            else:
-                self.send("ECHO", parsed)
+            await self._handle_message(parsed)
 
         logging.info("connection_subprocess finished")
+
+    async def _handle_message(self, msg: dict):
+        match msg["command"]:
+            case "PING":
+                self.send("PONG", msg["data"])
 
     async def _read(self):
         return await asyncio.get_event_loop().run_in_executor(None, sys.stdin.readline)

--- a/backend/modules/connection_runner.py
+++ b/backend/modules/connection_runner.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import logging
 import sys
+import time
 from typing import Any
 from aiortc import RTCSessionDescription
 
@@ -107,7 +108,9 @@ class ConnectionRunner:
 
         match command:
             case "PING":
-                self._send_command("PONG", msg["data"])
+                self._send_command(
+                    "PONG", {"original": msg["data"], "subprocess_time": time.time()}
+                )
             case "SEND":
                 await self._connection.send(data)
             case "CREATE_OFFER":

--- a/backend/modules/connection_runner.py
+++ b/backend/modules/connection_runner.py
@@ -124,6 +124,14 @@ class ConnectionRunner:
                     )
                     return
                 await self._connection.stop_subconnection(data)
+            case "SET_MUTED":
+                if self._connection is None:
+                    logging.warning(
+                        f"Failed to set muted, connection not defined. Data: {data}"
+                    )
+                    return
+                video, audio = data
+                await self._connection.set_muted(video, audio)
 
     async def _read(self):
         """TODO document"""

--- a/backend/modules/connection_subprocess.py
+++ b/backend/modules/connection_subprocess.py
@@ -245,7 +245,7 @@ class ConnectionSubprocess(ConnectionInterface):
                 continue
 
             if len(msg) == 0:
-                self._logger.error(
+                self._logger.debug(
                     "Stop listening for messages from subprocess, len(msg) == 0"
                 )
                 await self.stop()
@@ -385,7 +385,6 @@ async def connection_subprocess_factory(
     """
     # TODO change type of offer parameter to RTCSessionDescriptionDict
     offer_dict = RTCSessionDescriptionDict(sdp=offer.sdp, type=offer.type)  # type: ignore
-    print(offer_dict)
 
     connection = ConnectionSubprocess(
         offer_dict, message_handler, log_name_suffix, config

--- a/backend/modules/connection_subprocess.py
+++ b/backend/modules/connection_subprocess.py
@@ -115,7 +115,7 @@ class ConnectionSubprocess(ConnectionInterface):
         await self._send_command("HANDLE_ANSWER", answer)
 
     async def get_local_description(self) -> RTCSessionDescription:
-        """TODO document"""
+        """Get localdescription.  Blocks until subprocess sends localdescription."""
         self._logger.debug("Wait for local_description")
         await self._local_description_received.wait()
         self._logger.debug("Return local_description")
@@ -374,7 +374,7 @@ async def connection_subprocess_factory(
         WebRTC offer for building the connection to the client.
     message_handler : function (message: custom_types.message.MessageDict) -> None
         Message handler for ConnectionSubprocess.  ConnectionSubprocess will pass parsed
-         MessageDicts to this handler.
+        MessageDicts to this handler.
     log_name_suffix : str
         Suffix for logger used in Connection.  Format: Connection-<log_name_suffix>.
 

--- a/backend/modules/connection_subprocess.py
+++ b/backend/modules/connection_subprocess.py
@@ -167,7 +167,7 @@ class ConnectionSubprocess(ConnectionInterface):
 
     async def _ping(self):
         """Send PING message in interval, until self._running is False."""
-        await asyncio.sleep(10)
+        await asyncio.sleep(6)
         self._logger.debug("Start PING loop")
         while True:
             async with self._running_lock:
@@ -228,8 +228,14 @@ class ConnectionSubprocess(ConnectionInterface):
                 )
                 self._local_description_received.set()
             case "PONG":
-                t = round((time.time() - data) * 1000, 2)
-                self._logger.debug(f"Subprocess ping time: {t}ms")
+                t = time.time()
+                rtt = round((t - data["original"]) * 1000, 2)
+                to_time = round((data["subprocess_time"] - data["original"]) * 1000, 2)
+                back_time = round((t - data["subprocess_time"]) * 1000, 2)
+                self._logger.debug(
+                    f"Subprocess ping: RTT: {rtt}ms, to subprocess: {to_time}ms, back: "
+                    f"{back_time}ms"
+                )
             case "STATE_CHANGE":
                 self._set_state(ConnectionState(data))
             case "API":

--- a/backend/modules/connection_subprocess.py
+++ b/backend/modules/connection_subprocess.py
@@ -13,6 +13,7 @@ from asyncio.subprocess import Process, PIPE, create_subprocess_exec
 from modules import BACKEND_DIR
 from modules.connection_state import ConnectionState
 from modules.connection_interface import ConnectionInterface
+from modules.subprocess_logging import handle_log_from_subprocess
 
 from custom_types.message import MessageDict
 from custom_types.connection import RTCSessionDescriptionDict
@@ -240,6 +241,8 @@ class ConnectionSubprocess(ConnectionInterface):
                 await self._message_handler(data)
             case "SUBSCRIBER_OFFER":
                 await self._subscriber_offers.put(data)
+            case "LOG":
+                handle_log_from_subprocess(data, self._logger)
 
     async def _log_final_stdout_stderr(self):
         if self._process is None:

--- a/backend/modules/connection_subprocess.py
+++ b/backend/modules/connection_subprocess.py
@@ -236,6 +236,8 @@ class ConnectionSubprocess(ConnectionInterface):
             case "PONG":
                 t = round((time.time() - msg["data"]) * 1000, 2)
                 self._logger.info(f"Subprocess ping time: {t}ms")
+            case "STATE_CHANGE":
+                self._set_state(ConnectionState(msg["data"]))
 
     async def _log_final_stdout_stderr(self):
         if self._process is None:

--- a/backend/modules/connection_subprocess.py
+++ b/backend/modules/connection_subprocess.py
@@ -1,0 +1,226 @@
+"""TODO document"""
+
+import asyncio
+import json
+import logging
+from os.path import join
+import sys
+from typing import Any, Callable, Coroutine, Tuple
+from aiortc import MediaStreamTrack, RTCSessionDescription
+from asyncio.subprocess import Process, PIPE, create_subprocess_exec
+
+from modules import BACKEND_DIR
+from modules.connection_state import ConnectionState
+from modules.connection_interface import ConnectionInterface
+from modules.tracks import AudioTrackHandler, VideoTrackHandler
+
+from custom_types.message import MessageDict
+from custom_types.connection import RTCSessionDescriptionDict
+from custom_types.participant_summary import ParticipantSummaryDict
+
+
+class ConnectionSubprocess(ConnectionInterface):
+    """TODO document"""
+
+    _offer: RTCSessionDescriptionDict
+    _log_name_suffix: str
+    _message_handler: Callable[[MessageDict], Coroutine[Any, Any, None]]
+
+    _running_lock: asyncio.Lock
+    _running: bool
+    _process: Process | None
+    _state: ConnectionState
+    _logger: logging.Logger
+    _tasks: list[asyncio.Task]
+
+    _local_description_received: asyncio.Event
+    _local_description: RTCSessionDescription | None
+
+    def __init__(
+        self,
+        offer: RTCSessionDescriptionDict,
+        message_handler: Callable[[MessageDict], Coroutine[Any, Any, None]],
+        log_name_suffix: str,
+    ):
+        """TODO document"""
+        super().__init__()
+        self._offer = offer
+        self._log_name_suffix = log_name_suffix
+        self._message_handler = message_handler
+
+        self._running_lock = asyncio.Lock()
+        self._running = True
+        self._process = None
+        self._state = ConnectionState.NEW
+        self._logger = logging.getLogger("ConnectionSubprocess")
+
+        self._local_description_received = asyncio.Event()
+        self._local_description = None
+
+        self._tasks = [
+            asyncio.create_task(self._run(), name=f"ConnectionSubprocess.run")
+        ]
+
+    async def _run(self) -> None:
+        """TODO document"""
+        self._logger.debug("Starting subprocess")
+
+        # Start subprocess
+        program = [
+            sys.executable,
+            join(BACKEND_DIR, "subprocess_main.py"),
+            "-l",
+            f"{self._log_name_suffix}",
+            "-o",
+            f"{json.dumps(self._offer)}",
+        ]
+        program_summary = program[:3] + [
+            program[3][:10] + ("..." if len(program[3]) >= 10 else "")
+        ]
+
+        self._logger.debug(f"Starting subprocess: {program_summary}")
+        self._process = await create_subprocess_exec(
+            *program, stdin=PIPE, stderr=PIPE, stdout=PIPE
+        )
+        self._logger.debug(f"Subprocess started. PID: {self._process.pid}")
+
+        # Create task listening for messages from subprocess
+        self._tasks.append(
+            asyncio.create_task(
+                self._wait_for_messages(),
+                name="ConnectionSubprocess._wait_for_messages",
+            )
+        )
+
+        # Wait for process exit
+        stdout, stderr = await self._process.communicate()
+        self._logger.debug(
+            f"Subprocess exited with returncode: {self._process.returncode}"
+        )
+        if stdout:
+            self._logger.debug(f"[stdout START]:\n {stdout.decode()}\n[stdout END]")
+        if stderr:
+            self._logger.error(f"[stderr START]:\n {stderr.decode()}\n[stderr END]")
+
+    async def _wait_for_messages(self):
+        """TODO document"""
+        self._logger.debug("_wait_for_messages")
+        if self._process is None:
+            self._logger.error("Failed to wait for messages, _process is None")
+            return
+        if self._process.stdout is None:
+            self._logger.error("Failed to wait for messages, _process.stdout is None")
+            return
+
+        # TODO
+        timeout = 1
+
+        while True:
+            async with self._running_lock:
+                if not self._running:
+                    self._logger.debug(f"Return from _wait_for_messages, running=False")
+                    return
+
+            try:
+                self._logger.debug(f"_wait_for_messages - wait for {timeout}s")
+                msg = await self._process.stdout.readline()
+            except asyncio.TimeoutError:
+                self._logger.debug("_wait_for_messages - timeout")
+                continue
+
+            try:
+                parsed = json.loads(msg)
+            except (json.JSONDecodeError, TypeError) as e:
+                self._logger.error(f"Failed to parse message from subprocess: {e}")
+                continue
+
+            self._logger.debug(f"Received: {parsed}")
+
+            await self.handle_process_message(parsed)
+
+    async def handle_process_message(self, msg: dict):
+        match msg["command"]:
+            case "SET_LOCAL_DESCRIPTION":
+                self._local_description = RTCSessionDescription(
+                    msg["data"]["sdp"], msg["data"]["type"]
+                )
+                self._local_description_received.set()
+
+    async def get_local_description(self) -> RTCSessionDescription:
+        """TODO document"""
+        await self._local_description_received.wait()
+        assert self._local_description is not None
+        return self._local_description
+
+    async def stop(self) -> None:
+        """TODO document"""
+        self._logger.debug("STOP called in ConnectionSubprocess")
+        if self._process is not None:
+            self._process.terminate()
+        async with self._running_lock:
+            self._running = False
+        asyncio.gather(*self._tasks)
+
+    def send(self, command, data):
+        """Send to main process"""
+        data = json.dumps({"command": command, "data": data})
+        if self._process is None:
+            self._logger.error(f"Failed send {data}, _process is None")
+            return
+        if self._process.stdin is None:
+            self._logger.error(f"Failed send {data}, _process.stdin is None")
+            return
+
+        self._logger.debug(f"Sending: {data}")
+        self._process.stdin.write(data.encode("utf-8") + b"\n")
+
+    @property
+    def state(self) -> ConnectionState:
+        """TODO document"""
+        return self._state
+
+    @property
+    def incoming_audio(self) -> AudioTrackHandler | None:
+        """TODO document"""
+        # TODO implement
+        raise NotImplementedError()
+
+    @property
+    def incoming_video(self) -> VideoTrackHandler | None:
+        """TODO document"""
+        # TODO implement
+        raise NotImplementedError()
+
+    async def add_outgoing_stream(
+        self,
+        video_track: MediaStreamTrack,
+        audio_track: MediaStreamTrack,
+        participant_summary: ParticipantSummaryDict | None,
+    ) -> str:
+        """TODO document"""
+        # TODO implement
+        raise NotImplementedError()
+
+    async def stop_outgoing_stream(self, stream_id: str) -> bool:
+        """TODO document"""
+        # TODO implement
+        raise NotImplementedError()
+
+
+ConnectionInterface.register(ConnectionSubprocess)
+
+
+async def connection_subprocess_factory(
+    offer: RTCSessionDescription,
+    message_handler: Callable[[MessageDict], Coroutine[Any, Any, None]],
+    log_name_suffix: str,
+) -> Tuple[RTCSessionDescription, ConnectionSubprocess]:
+    """TODO document"""
+    # TODO change type of offer parameter to RTCSessionDescriptionDict
+    offer_dict = RTCSessionDescriptionDict(sdp=offer.sdp, type=offer.type)  # type: ignore
+
+    connection = ConnectionSubprocess(offer_dict, message_handler, log_name_suffix)
+
+    local_description = await connection.get_local_description()
+
+    return (local_description, connection)

--- a/backend/modules/connection_subprocess.py
+++ b/backend/modules/connection_subprocess.py
@@ -200,9 +200,9 @@ class ConnectionSubprocess(ConnectionInterface):
 
             self._logger.debug("_wait_for_messages - readline")
             try:
-                msg = await asyncio.wait_for(self._process.stdout.readline(), 5)
-            except asyncio.TimeoutError:
-                self._logger.debug("_wait_for_messages - timeout")
+                msg = await self._process.stdout.readline()
+            except ValueError:
+                self._logger.error("readline() failed, message was to long.")
                 continue
 
             if len(msg) == 0:

--- a/backend/modules/connection_subprocess.py
+++ b/backend/modules/connection_subprocess.py
@@ -112,10 +112,9 @@ class ConnectionSubprocess(ConnectionInterface):
         await self._send_command("STOP_SUBCONNECTION", subconnection_id)
         return True
 
-    def set_muted(self, video: bool, audio: bool) -> None:
+    async def set_muted(self, video: bool, audio: bool) -> None:
         """TODO document"""
-        # TODO implement
-        pass
+        await self._send_command("SET_MUTED", (video, audio))
 
     def _set_state(self, state: ConnectionState):
         """Set connection state and emit `state_change` event."""
@@ -264,6 +263,7 @@ class ConnectionSubprocess(ConnectionInterface):
         | float
         | dict
         | None
+        | tuple
         | ParticipantSummaryDict
         | ConnectionAnswerDict
         | MessageDict,

--- a/backend/modules/connection_subprocess.py
+++ b/backend/modules/connection_subprocess.py
@@ -109,8 +109,8 @@ class ConnectionSubprocess(ConnectionInterface):
 
     async def stop_subconnection(self, subconnection_id: str) -> bool:
         """TODO document"""
-        # TODO implement
-        raise NotImplementedError()
+        await self._send_command("STOP_SUBCONNECTION", subconnection_id)
+        return True
 
     def set_muted(self, video: bool, audio: bool) -> None:
         """TODO document"""

--- a/backend/modules/data.py
+++ b/backend/modules/data.py
@@ -58,7 +58,6 @@ class _BaseDataClass(AsyncIOEventEmitter):
         """Emit an `update` event if `_emit_updates` is true."""
         try:
             if self._emit_updates:
-                print("_emit_update_event", self)
                 self.emit("update", self)
         except AttributeError as e:
             pass
@@ -492,7 +491,6 @@ class SessionData(_BaseDataClass):
         _handle_updates() :
             Handle updates in data. See for information about `self._trigger_updates`.
         """
-        print("_set_variables")
         if session_dict["id"] == "":
             raise ValueError('Missing "id" in session dict.')
 
@@ -511,14 +509,12 @@ class SessionData(_BaseDataClass):
         self.start_time = session_dict["end_time"]
 
         # Remove event listeners from current participants (before deleting them)
-        print("removing event listeners from old participants")
         for old_participant in self.participants.values():
             old_participant.remove_all_listeners()
 
         # Parse participants
         _generate_participant_ids(session_dict)
         self.participants = {}
-        print("Generating new participants:\n  -> ", session_dict["participants"])
         for participant_dict in session_dict["participants"]:
             p = participant_data_factory(participant_dict)
             p.add_listener("update", self._emit_update_event)

--- a/backend/modules/experiment.py
+++ b/backend/modules/experiment.py
@@ -317,7 +317,7 @@ class Experiment:
         # Save banned state in session / participant data
         participant_data.banned = True
 
-    def mute_participant(self, participant_id: str, video: bool, audio: bool):
+    async def mute_participant(self, participant_id: str, video: bool, audio: bool):
         """Set the muted state for the participant with `participant_id`.
 
         Parameters
@@ -331,7 +331,7 @@ class Experiment:
         """
         # Mute participant if participant is already connected
         if participant_id in self._participants:
-            self._participants[participant_id].set_muted(video, audio)
+            await self._participants[participant_id].set_muted(video, audio)
 
     def add_experimenter(self, experimenter: _experimenter.Experimenter):
         """Add experimenter to experiment.

--- a/backend/modules/experimenter.py
+++ b/backend/modules/experimenter.py
@@ -28,6 +28,7 @@ from custom_types.session_id_request import (
 
 from modules.connection_state import ConnectionState
 from modules.connection import connection_factory
+from modules.connection_subprocess import connection_subprocess_factory
 from modules.exceptions import ErrorDictException
 from modules.user import User
 import modules.experiment as _experiment
@@ -731,8 +732,16 @@ async def experimenter_factory(
         representing the client.
     """
     experimenter = Experimenter(id, hub)
-    answer, connection = await connection_factory(
-        offer, experimenter.handle_message, f"E-{id}"
-    )
+    log_name_suffix = f"E-{id}"
+
+    if hub.config.experimenter_multiprocessing:
+        answer, connection = await connection_subprocess_factory(
+            offer, experimenter.handle_message, log_name_suffix, hub.config
+        )
+    else:
+        answer, connection = await connection_factory(
+            offer, experimenter.handle_message, log_name_suffix
+        )
+
     experimenter.set_connection(connection)
     return (answer, experimenter)

--- a/backend/modules/experimenter.py
+++ b/backend/modules/experimenter.py
@@ -620,7 +620,7 @@ class Experimenter(User):
             )
 
         experiment = self._get_experiment_or_raise("Failed to mute participant.")
-        experiment.mute_participant(
+        await experiment.mute_participant(
             data["participant_id"], data["mute_video"], data["mute_audio"]
         )
 

--- a/backend/modules/experimenter.py
+++ b/backend/modules/experimenter.py
@@ -9,7 +9,7 @@ modules.connection.Connection.
 from __future__ import annotations
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Coroutine
 from aiortc import RTCSessionDescription
 
 from custom_types.error import ErrorDict
@@ -114,12 +114,12 @@ class Experimenter(User):
     async def _subscribe_to_participants_streams(self) -> None:
         """Subscribe to all participants in `self._experiment`."""
         if self._experiment is not None:
-            tasks = []
+            coros: list[Coroutine] = []
             for p in self._experiment.participants.values():
                 if p is self:
                     continue
-                tasks.append(self.subscribe_to(p))
-            await asyncio.gather(*tasks)
+                coros.append(p.add_subscriber(self))
+            await asyncio.gather(*coros)
 
     async def _handle_get_session_list(self, _) -> MessageDict:
         """Handle requests with type `GET_SESSION_LIST`.

--- a/backend/modules/hub.py
+++ b/backend/modules/hub.py
@@ -251,7 +251,7 @@ class Hub:
             )
 
         answer, _ = await _participant.participant_factory(
-            offer, participant_id, experiment, participantData
+            offer, participant_id, experiment, participantData, self.config
         )
 
         return (answer, participantData.as_summary_dict())

--- a/backend/modules/hub.py
+++ b/backend/modules/hub.py
@@ -52,7 +52,7 @@ class Hub:
         # Setup logging
         logging.basicConfig(
             level=logging.getLevelName(self.config.log),
-            format="%(levelname)s:%(name)s: %(message)s",
+            format="%(asctime)s:%(levelname)s:%(name)s: %(message)s",
             filename=self.config.log_file,
         )
         self._logger = logging.getLogger("Hub")

--- a/backend/modules/hub.py
+++ b/backend/modules/hub.py
@@ -12,6 +12,7 @@ from modules.experiment import Experiment
 from modules.config import Config
 from modules.util import generate_unique_id
 from modules.exceptions import ErrorDictException
+from modules.util import get_system_specs
 
 import modules.server as _server
 import modules.experiment as _experiment
@@ -56,6 +57,7 @@ class Hub:
         )
         self._logger = logging.getLogger("Hub")
         self._logger.debug("Initializing Hub")
+        self._logger.debug(f"System: {get_system_specs()}")
 
         # Set logging level for libraries
         dependencies_log_level = logging.getLevelName(self.config.log_dependencies)

--- a/backend/modules/subprocess_logging.py
+++ b/backend/modules/subprocess_logging.py
@@ -24,6 +24,9 @@ class SubprocessLoggingHandler(logging.StreamHandler):
             "levelname": record.levelname,
             "levelno": record.levelno,
             "msg": record.getMessage(),
+            "created": record.created,
+            "msecs": record.msecs,
+            "relativeCreated": record.relativeCreated,
         }
         self._send_command("LOG", data)
 

--- a/backend/modules/subprocess_logging.py
+++ b/backend/modules/subprocess_logging.py
@@ -1,4 +1,4 @@
-"""TODO Document"""
+"""Provides the `SubprocessLoggingHandler` class."""
 
 import os
 import logging
@@ -6,19 +6,45 @@ from typing import Callable
 
 
 class SubprocessLoggingHandler(logging.StreamHandler):
-    """TODO Document"""
+    """Log handler relaying subprocess logs to main process.
+
+    Extends logging.StreamHandler.  Sends incoming logs to main process using
+    `send_command`.  The main process can then use `handle_log_from_subprocess` to parse
+    and log the log records.
+
+    See Also
+    --------
+    handle_log_from_subprocess : handle incoming logs from this handler.
+    """
 
     _send_command: Callable[[str, dict | str], None]
     _pid: str
 
     def __init__(self, send_command: Callable[[str, dict | str], None]):
-        """TODO Document"""
+        """Initiate new SubprocessLoggingHandler.
+
+        Parameters
+        ----------
+        send_command : Callable(str, dict) -> None
+            Function used to send commands (`LOG`) to main process.
+
+        Examples
+        --------
+        >>> handler = SubprocessLoggingHandler(send_command)
+        >>> logging.basicConfig(handlers=[handler], ...)
+        """
         super().__init__()
         self._send_command = send_command
         self._pid = str(os.getpid())
 
     def emit(self, record: logging.LogRecord):
-        """TODO Document"""
+        """Send record to main process using `LOG` command and `send_command`.
+
+        Parameters
+        ----------
+        record : logging.LogRecord
+            Log record that will be send to the main process.
+        """
         data = {
             "name": f"{record.name}[{self._pid}]",
             "levelname": record.levelname,
@@ -32,6 +58,15 @@ class SubprocessLoggingHandler(logging.StreamHandler):
 
 
 def handle_log_from_subprocess(log_data: dict, logger: logging.Logger):
-    """TODO Document"""
+    """Parse and handle a log record received from a subprocess.
+
+    Parameters
+    ----------
+    log_data : dict
+        Data received in `LOG` command from subprocess.
+    logger : logging.Logger
+        Logger that is used to handle `log_data`.  As long as log_data contains `name`,
+        the name of `logger` is not used.
+    """
     log_record = logging.makeLogRecord(log_data)
     logger.handle(log_record)

--- a/backend/modules/subprocess_logging.py
+++ b/backend/modules/subprocess_logging.py
@@ -20,7 +20,7 @@ class SubprocessLoggingHandler(logging.StreamHandler):
     def emit(self, record: logging.LogRecord):
         """TODO Document"""
         data = {
-            "name": f"[{self._pid}]{record.name}",
+            "name": f"{record.name}[{self._pid}]",
             "levelname": record.levelname,
             "levelno": record.levelno,
             "msg": record.getMessage(),

--- a/backend/modules/subprocess_logging.py
+++ b/backend/modules/subprocess_logging.py
@@ -1,0 +1,34 @@
+"""TODO Document"""
+
+import os
+import logging
+from typing import Callable
+
+
+class SubprocessLoggingHandler(logging.StreamHandler):
+    """TODO Document"""
+
+    _send_command: Callable[[str, dict | str], None]
+    _pid: str
+
+    def __init__(self, send_command: Callable[[str, dict | str], None]):
+        """TODO Document"""
+        super().__init__()
+        self._send_command = send_command
+        self._pid = str(os.getpid())
+
+    def emit(self, record: logging.LogRecord):
+        """TODO Document"""
+        data = {
+            "name": f"[{self._pid}]{record.name}",
+            "levelname": record.levelname,
+            "levelno": record.levelno,
+            "msg": record.getMessage(),
+        }
+        self._send_command("LOG", data)
+
+
+def handle_log_from_subprocess(log_data: dict, logger: logging.Logger):
+    """TODO Document"""
+    log_record = logging.makeLogRecord(log_data)
+    logger.handle(log_record)

--- a/backend/modules/tracks.py
+++ b/backend/modules/tracks.py
@@ -1,7 +1,13 @@
 """Provide AudioTrackHandler and VideoTrackHandler for handing and distributing tracks.
 """
 
-from aiortc.mediastreams import MediaStreamTrack, MediaStreamError
+from typing import Optional
+from aiortc.mediastreams import (
+    MediaStreamTrack,
+    MediaStreamError,
+    AudioStreamTrack,
+    VideoStreamTrack,
+)
 from aiortc.contrib.media import MediaRelay
 from av import VideoFrame, AudioFrame
 from PIL import Image
@@ -15,27 +21,63 @@ class AudioTrackHandler(MediaStreamTrack):
 
     kind = "audio"
 
-    track: MediaStreamTrack
+    _track: MediaStreamTrack | AudioStreamTrack
     muted: bool
     _relay: MediaRelay
 
-    def __init__(self, track: MediaStreamTrack, muted: bool = False) -> None:
+    def __init__(
+        self, track: MediaStreamTrack | None = None, muted: bool = False
+    ) -> None:
         """Initialize new AudioTrackHandler for `track`.
 
         Parameters
         ----------
         track : aiortc.mediastreams.MediaStreamTrack
-            Track this handler should manage and distribute.
+            Track this handler should manage and distribute.  None if track is set
+            later.
         muted : bool, default False
             Whether this track should be muted.
         """
         super().__init__()
-        self.track = track
+        self._track = track if track is not None else AudioStreamTrack()
         self.muted = muted
         self._relay = MediaRelay()
 
         # Forward the ended event to this handler.
-        track.on("ended", self.stop)
+        self._track.add_listener("ended", self.stop)
+
+    @property
+    def track(self):
+        """Get source track for this AudioTrackHandler.
+
+        Notes
+        -----
+        Use `subscribe` to add a subscriber to this track.
+        """
+        return self._track
+
+    @track.setter
+    def track(self, value: MediaStreamTrack):
+        """Set source track for this AudioTrackHandler.
+
+        Parameters
+        ----------
+        value : MediaStreamTrack
+            New source track for this AudioTrackHandler.  `kind` of value must be
+            "audio".
+
+        Raises
+        ------
+        ValueError
+            If `kind` of value is not "audio".
+        """
+        if value.kind != "audio":
+            raise ValueError(
+                'Source track for AudioTrackHandler must be of kind: "audio"'
+            )
+        self._track.remove_listener("ended", self.stop)
+        self._track = value
+        self._track.add_listener("ended", self.stop)
 
     def subscribe(self) -> MediaStreamTrack:
         """Subscribe to this track.
@@ -96,36 +138,72 @@ class VideoTrackHandler(MediaStreamTrack):
 
     kind = "video"
 
-    track: MediaStreamTrack
+    _track: MediaStreamTrack
     muted: bool
     _relay: MediaRelay
 
     _muted_frame_img: Image.Image
     _muted_frame: VideoFrame
 
-    def __init__(self, track: MediaStreamTrack, muted: bool = False) -> None:
+    def __init__(
+        self, track: MediaStreamTrack | None = None, muted: bool = False
+    ) -> None:
         """Initialize new VideoTrackHandler for `track`.
 
         Parameters
         ----------
-        track : aiortc.mediastreams.MediaStreamTrack
-            Track this handler should manage and distribute.
+        track : aiortc.mediastreams.MediaStreamTrack or None
+            Track this handler should manage and distribute.  None if track is set
+            later.
         muted : bool, default False
             Whether this track should be muted.  When muted, a still image will be
             broadcasted instead of the input `track`.
         """
         super().__init__()
-        self.track = track
+        self._track = track if track is not None else VideoStreamTrack()
         self.muted = muted
         self._relay = MediaRelay()
 
         # Forward the ended event to this handler.
-        track.on("ended", self.stop)
+        self._track.add_listener("ended", self.stop)
 
         # Load image that will be broadcasted when track is muted.
         img_path = join(BACKEND_DIR, "images/muted.png")
         self._muted_frame_img = Image.open(img_path)
         self.muted_frame = VideoFrame.from_image(self._muted_frame_img)
+
+    @property
+    def track(self):
+        """Get source track for this AudioTrackHandler.
+
+        Notes
+        -----
+        Use `subscribe` to add a subscriber to this track.
+        """
+        return self._track
+
+    @track.setter
+    def track(self, value: MediaStreamTrack):
+        """Set source track for this VideoTrackHandler.
+
+        Parameters
+        ----------
+        value : MediaStreamTrack
+            New source track for this VideoTrackHandler.  `kind` of value must be
+            "video".
+
+        Raises
+        ------
+        ValueError
+            If `kind` of value is not "video".
+        """
+        if value.kind != "video":
+            raise ValueError(
+                'Source track for VideoTrackHandler must be of kind: "video"'
+            )
+        self._track.remove_listener("ended", self.stop)
+        self._track = value
+        self._track.add_listener("ended", self.stop)
 
     def subscribe(self) -> MediaStreamTrack:
         """Subscribe to this track.

--- a/backend/modules/user.py
+++ b/backend/modules/user.py
@@ -39,6 +39,8 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
     - `tracks_complete` : tuple of modules.track.VideoTrackHandler and modules.track.AudioTrackHandler
         Forwarded from modules.connection.Connection.  Emitted when both tracks are
         received from the client and ready to be distributed / subscribed to.
+    - `CONNECTION_ANSWER` : custom_types.connection.ConnectionAnswerDict
+        CONNECTION_ANSWER message received from a client.
 
     Attributes
     ----------
@@ -241,7 +243,6 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
 
         endpoint = message["type"]
 
-        # TODO temp
         if endpoint == "CONNECTION_ANSWER":
             if not is_valid_connection_answer_dict(message["data"]):
                 self._logger.warning(f"Received invalid CONNECTION_ANSWER")

--- a/backend/modules/user.py
+++ b/backend/modules/user.py
@@ -36,9 +36,6 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
     Extends AsyncIOEventEmitter, providing the following events:
     - `disconnected` : modules.user.User
         Emitted when the connection with the client closes.
-    - `tracks_complete` : tuple of modules.track.VideoTrackHandler and modules.track.AudioTrackHandler
-        Forwarded from modules.connection.Connection.  Emitted when both tracks are
-        received from the client and ready to be distributed / subscribed to.
     - `CONNECTION_ANSWER` : custom_types.connection.ConnectionAnswerDict
         CONNECTION_ANSWER message received from a client.
 
@@ -157,7 +154,6 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
         self._connection.add_listener(
             "state_change", self._handle_connection_state_change_user
         )
-        self._connection.on("tracks_complete", self._emit_tracks_complete_event)
 
     async def send(self, message: MessageDict) -> None:
         """Send a custom_types.message.MessageDict to the connected client.
@@ -316,15 +312,6 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
         self._logger.info("Disconnected")
         self.emit("disconnected", self)
         self.remove_all_listeners()
-
-    def _emit_tracks_complete_event(
-        self, tracks: Tuple[VideoTrackHandler, AudioTrackHandler]
-    ) -> None:
-        """Emits the `tracks_complete` event with `data`.
-
-        Use to forward the event from the connection.
-        """
-        self.emit("tracks_complete", tracks)
 
     def _handle_connection_state_change_user(self, state: ConnectionState) -> None:
         """Calls _handle_disconnect if state is CLOSED or FAILED.

--- a/backend/modules/user.py
+++ b/backend/modules/user.py
@@ -7,21 +7,25 @@ modules.experimenter.Experimenter : Experimenter implementation of User.
 """
 
 from __future__ import annotations
+
 import logging
 import traceback
 from abc import ABCMeta, abstractmethod
-from typing import Callable, Any, Coroutine, Tuple
 from pyee.asyncio import AsyncIOEventEmitter
+from typing import Callable, Any, Coroutine, Tuple
 
-from custom_types.participant_summary import ParticipantSummaryDict
-from custom_types.message import MessageDict
 from custom_types.error import ErrorDict
+from custom_types.message import MessageDict
+from custom_types.participant_summary import ParticipantSummaryDict
 
-from modules.tracks import AudioTrackHandler, VideoTrackHandler
 from modules.exceptions import ErrorDictException
 from modules.connection_state import ConnectionState
-from custom_types.connection import ConnectionAnswerDict
 from modules.connection_interface import ConnectionInterface
+from modules.tracks import AudioTrackHandler, VideoTrackHandler
+from custom_types.connection import (
+    ConnectionAnswerDict,
+    is_valid_connection_answer_dict,
+)
 
 
 class User(AsyncIOEventEmitter, metaclass=ABCMeta):
@@ -230,6 +234,9 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
 
         # TODO temp
         if endpoint == "CONNECTION_ANSWER":
+            if not is_valid_connection_answer_dict(message["data"]):
+                self._logger.warning(f"Received invalid CONNECTION_ANSWER")
+                return
             self.emit("CONNECTION_ANSWER", message["data"])
             return
 

--- a/backend/modules/user.py
+++ b/backend/modules/user.py
@@ -262,7 +262,7 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
             if response is not None:
                 await self.send(response)
 
-    def set_muted(self, video: bool, audio: bool) -> None:
+    async def set_muted(self, video: bool, audio: bool) -> None:
         """Set the muted state for this user.
 
         Parameters
@@ -278,7 +278,7 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
         self._muted_video = video
         self._muted_audio = audio
 
-        self._connection.set_muted(video, audio)
+        await self._connection.set_muted(video, audio)
 
     def _handle_disconnect(self) -> None:
         """Handle this user disconnecting.

--- a/backend/modules/user.py
+++ b/backend/modules/user.py
@@ -181,7 +181,6 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
 
         @user.on("CONNECTION_ANSWER")
         async def _handle_answer(answer: ConnectionAnswerDict):
-            # TODO Ensure id is unique for all users / connections
             if answer["id"] == offer["id"]:
                 await self._connection.handle_subscriber_answer(answer)
                 user.remove_listener("CONNECTION_ANSWER", _handle_answer)

--- a/backend/modules/user.py
+++ b/backend/modules/user.py
@@ -173,7 +173,17 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
         self._handle_disconnect()
 
     async def add_subscriber(self, user: User) -> None:
-        """TODO document"""
+        """Add `user` as a subscriber to this User.
+
+        Sends a `CONNECTION_OFFER` to `user` and waits for an `CONNECTION_ANSWER`.
+        After receiving the answer, the incoming streams from this user will also be
+        send to `user`.
+
+        Parameters
+        ----------
+        user : modules.user.User
+            New subscriber to this User.
+        """
         self._logger.debug(f"Adding subscriber: {repr(user)}")
         offer = await self._connection.create_subscriber_offer(self.get_summary())
         msg = MessageDict(type="CONNECTION_OFFER", data=offer)

--- a/backend/modules/user.py
+++ b/backend/modules/user.py
@@ -20,7 +20,7 @@ from custom_types.error import ErrorDict
 from modules.tracks import AudioTrackHandler, VideoTrackHandler
 from modules.exceptions import ErrorDictException
 from modules.connection_state import ConnectionState
-import modules.connection as _connection
+from modules.connection_interface import ConnectionInterface
 
 
 class User(AsyncIOEventEmitter, metaclass=ABCMeta):
@@ -75,7 +75,7 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
     _logger: logging.Logger
     _muted_video: bool
     _muted_audio: bool
-    _connection: _connection.Connection
+    _connection: ConnectionInterface
     _handlers: dict[str, list[Callable[[Any], Coroutine[Any, Any, MessageDict | None]]]]
     __disconnected: bool
 
@@ -132,7 +132,7 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
         """
         return None
 
-    def set_connection(self, connection: _connection.Connection) -> None:
+    def set_connection(self, connection: ConnectionInterface) -> None:
         """Set the connection of this user.
 
         This should only be used once before using this User.  See factory functions.

--- a/backend/modules/user.py
+++ b/backend/modules/user.py
@@ -232,7 +232,9 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
         """Handle incoming message from client.
 
         Pass Message data to all functions registered to message type endpoint using
-        `on`.
+        `on_message`.  Note that `on` is listening for events using AsyncIOEventEmitter,
+        not api requests.
+
         Send responses or exceptions from message handlers to client.
 
         Parameters
@@ -246,6 +248,12 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
         if endpoint == "CONNECTION_ANSWER":
             if not is_valid_connection_answer_dict(message["data"]):
                 self._logger.warning(f"Received invalid CONNECTION_ANSWER")
+                err = ErrorDict(
+                    code=400,
+                    type="INVALID_DATATYPE",
+                    description="Invalid connection answer dict",
+                )
+                await self.send(MessageDict(type="ERROR", data=err))
                 return
             self.emit("CONNECTION_ANSWER", message["data"])
             return

--- a/backend/modules/user.py
+++ b/backend/modules/user.py
@@ -165,7 +165,7 @@ class User(AsyncIOEventEmitter, metaclass=ABCMeta):
     async def disconnect(self) -> None:
         """Disconnect.  Closes the connection with the client."""
         await self._connection.stop()
-        self._handle_disconnect
+        self._handle_disconnect()
 
     async def subscribe_to(self, user: User) -> None:
         """Add incoming tracks from `user` to this User.

--- a/backend/modules/util.py
+++ b/backend/modules/util.py
@@ -1,6 +1,8 @@
 """Provide utility functions used by different parts of the software."""
 
+import os
 import uuid
+import platform
 
 
 def generate_unique_id(existing_ids: list[str]):
@@ -25,3 +27,17 @@ def generate_unique_id(existing_ids: list[str]):
     while id in existing_ids:
         id = uuid.uuid4().hex[:10]
     return id
+
+
+def get_system_specs() -> dict:
+    """Get general system specs / info."""
+    return {
+        "python_version": platform.python_version(),
+        "system": platform.system(),
+        "release": platform.release(),
+        "version": platform.version(),
+        "machine": platform.machine(),
+        "platform": platform.platform(),
+        "processor": platform.processor(),
+        "cpu_count": os.cpu_count(),
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ aiohttp_cors # dev only
 Pillow 
 av
 argparse 
+shortuuid

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ pyee
 aiohttp_cors # dev only
 Pillow 
 av
+argparse 

--- a/backend/subprocess_main.py
+++ b/backend/subprocess_main.py
@@ -47,7 +47,7 @@ def parse_args() -> Tuple[RTCSessionDescription, str]:
 async def main() -> None:
     # TODO logging config
     logging.basicConfig(level=logging.DEBUG, filename="./subprocess.log")
-    dependencies_log_level = logging.DEBUG
+    dependencies_log_level = logging.INFO
     logging.getLogger("aiohttp").setLevel(dependencies_log_level)
     logging.getLogger("aioice").setLevel(dependencies_log_level)
     logging.getLogger("aiortc").setLevel(dependencies_log_level)
@@ -59,6 +59,7 @@ async def main() -> None:
 
     runner = ConnectionRunner()
     await runner.run(offer, log_name_suffix)
+    logging.debug(f"runner.run() returned")
 
 
 if __name__ == "__main__":

--- a/backend/subprocess_main.py
+++ b/backend/subprocess_main.py
@@ -1,0 +1,65 @@
+import asyncio
+import json
+import logging
+from argparse import ArgumentParser
+from typing import Tuple
+from aiortc import RTCSessionDescription
+
+from custom_types.connection import (
+    is_valid_rtc_session_description_dict,
+    RTCSessionDescriptionDict,
+)
+
+from modules.connection_runner import ConnectionRunner
+
+
+def parse_args() -> Tuple[RTCSessionDescription, str]:
+    """Parse command line arguments.
+
+    Raises
+    ------
+    ValueError
+        If the offer is invalid
+    """
+    parser = ArgumentParser()
+    parser.add_argument("-o", "--offer", dest="offer", required=True)
+    parser.add_argument(
+        "-l", "--log_name_suffix", dest="log_name_suffix", required=True
+    )
+    args = parser.parse_args()
+
+    # Check and parse offer
+    try:
+        offer_obj: RTCSessionDescriptionDict = json.loads(args.offer)
+    except (json.JSONDecodeError, TypeError) as e:
+        logging.error(f"Failed to parse offer received in command line arguments: {e}")
+        raise e
+
+    if not is_valid_rtc_session_description_dict(offer_obj):
+        logging.error("Offer parsed from command line arguments is invalid.")
+        raise ValueError("Invalid offer")
+
+    offer = RTCSessionDescription(offer_obj["sdp"], offer_obj["type"])
+
+    return (offer, args.log_name_suffix)
+
+
+async def main() -> None:
+    # TODO logging config
+    logging.basicConfig(level=logging.DEBUG, filename="./subprocess.log")
+    dependencies_log_level = logging.DEBUG
+    logging.getLogger("aiohttp").setLevel(dependencies_log_level)
+    logging.getLogger("aioice").setLevel(dependencies_log_level)
+    logging.getLogger("aiortc").setLevel(dependencies_log_level)
+    logging.getLogger("PIL").setLevel(dependencies_log_level)
+
+    offer, log_name_suffix = parse_args()
+
+    logging.debug(f"Arguments: log_name_suffix: {log_name_suffix}, offer: {offer}")
+
+    runner = ConnectionRunner()
+    await runner.run(offer, log_name_suffix)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/subprocess_main.py
+++ b/backend/subprocess_main.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
-import logging
 from argparse import ArgumentParser
+import sys
 from typing import Tuple
 from aiortc import RTCSessionDescription
 
@@ -32,11 +32,14 @@ def parse_args() -> Tuple[RTCSessionDescription, str]:
     try:
         offer_obj: RTCSessionDescriptionDict = json.loads(args.offer)
     except (json.JSONDecodeError, TypeError) as e:
-        logging.error(f"Failed to parse offer received in command line arguments: {e}")
+        print(
+            f"Failed to parse offer received in command line arguments: {e}",
+            file=sys.stderr,
+        )
         raise e
 
     if not is_valid_rtc_session_description_dict(offer_obj):
-        logging.error("Offer parsed from command line arguments is invalid.")
+        print("Offer parsed from command line arguments is invalid.", file=sys.stderr)
         raise ValueError("Invalid offer")
 
     offer = RTCSessionDescription(offer_obj["sdp"], offer_obj["type"])
@@ -45,21 +48,10 @@ def parse_args() -> Tuple[RTCSessionDescription, str]:
 
 
 async def main() -> None:
-    # TODO logging config
-    logging.basicConfig(level=logging.DEBUG, filename="./subprocess.log")
-    dependencies_log_level = logging.INFO
-    logging.getLogger("aiohttp").setLevel(dependencies_log_level)
-    logging.getLogger("aioice").setLevel(dependencies_log_level)
-    logging.getLogger("aiortc").setLevel(dependencies_log_level)
-    logging.getLogger("PIL").setLevel(dependencies_log_level)
-
     offer, log_name_suffix = parse_args()
-
-    logging.debug(f"Arguments: log_name_suffix: {log_name_suffix}, offer: {offer}")
 
     runner = ConnectionRunner()
     await runner.run(offer, log_name_suffix)
-    logging.debug(f"runner.run() returned")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add the option to execute Connections on dedicated subprocesses.

# Changes Overview

- Add time to logging
- Log (DEBUG) general system info on start
- Config -> add: `ping_subprocesses` (for debugging), `experimenter_multiprocessing` and `participant_multiprocessing`
- Add `ConnectionInterface`: Abstract class defining the interface provided by `Connection` & `ConnectionSubprocess` (new)
	- Also contains documentation for subclasses
- Add `ConnectionSubprocess`: Wrapper for Connection, implementing the above `ConnectionInterface` but executes the `Connection` on a dedicated subprocess. Handles communication with subprocess
	- *Connection, but on a subprocess*
- Add `ConnectionRunner`: counterpart to `ConnectionSubprocess`. When `ConnectionSubprocess` starts a new subprocess, `subprocess_main.py` (main for subprocesses) creates a new `ConnectionRunner` which handles the `Connection` and communication with the main process
- Add `SubprocessLoggingHandler`: Log handler. Relay logs in a subprocess to the main process, where they are logged.
- Changes to SubConnection
	- SubConnections now distribute the stream of their parent Connection instead of sending streams from other Connections ( / Users) to the parent connection. 
	- This way, streams do not need to be sent between processes, but a Connection executed on a subprocess distributes the incoming stream to other users.
- User's `subscribe_to` replaced by `add_subscriber` (see changes to SubConnection)
- Changes to Connection: Incoming audio / video tracks are now no longer accessible from outside the connection